### PR TITLE
Make version number in the plugin match next release

### DIFF
--- a/wp-experimental-features.php
+++ b/wp-experimental-features.php
@@ -5,9 +5,9 @@
  * Plugin Name: Experimental Features
  * Plugin URI:  https://github.com/alleyinteractive/wp-experimental-features
  * Description: Turn experimental features on and off via a checkbox in the admin.
- * Version:     1.2.0
+ * Version:     1.3.2
  * Author:      Alley
- * Author URI:  https://alley.co
+ * Author URI:  https://alley.com
  *
  * @package Experimental_Features
  */


### PR DESCRIPTION
Fixed the version number in the plugin main file which was causing confusion on the edit screen because the active version reporting is wrong. After merge, we will cut a new release for 1.3.2 that will include this fix.